### PR TITLE
Fixing bothering visual artifact

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,3 +16,10 @@ jobs:
 
       - name: Optimize map
         uses: thecodingmachine/map-optimizer-action@master
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: . # The folder the action should deploy.

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -24,6 +24,7 @@ jobs:
           ls -al
           git config --global user.email "d.negrier@thecodingmachine.com"
           git config --global user.name "David Négrier"
+          git checkout master
           git commit -am "Adding files"
 
       - name: Deploy
@@ -32,6 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: . # The folder the action should deploy.
+          BASE_BRANCH: master
 
       - name: Bash2
         run: |

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,7 +20,9 @@ jobs:
         uses: thecodingmachine/map-optimizer-action@master
 
       - name: Bash
-        run: ls -al
+        run: |
+          ls -al
+          git commit -am "Adding files"
 
 #      - name: Deploy
 #        uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,18 @@
+name: Optimize map and deploy
+
+on:
+  - push
+
+jobs:
+
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Optimize map
+        uses: thecodingmachine/map-optimizer-action@master

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Publish generated content to GitHub Pages
         uses: tsunematsu21/actions-publish-gh-pages@v1.0.1
         with:
-          dir: dist
+          dir: .
           branch: gh-pages
           token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,7 +1,9 @@
 name: Optimize map and deploy
 
 on:
-  - push
+  push:
+    branches:
+      - master
 
 jobs:
 
@@ -16,6 +18,10 @@ jobs:
 
       - name: Optimize map
         uses: thecodingmachine/map-optimizer-action@master
+
+      - name: Bash
+        uses: jdickey/bash@master
+        args: ["ls -al"]
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,9 +22,18 @@ jobs:
       - name: Bash
         run: ls -al
 
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+#      - name: Deploy
+#        uses: JamesIves/github-pages-deploy-action@releases/v3
+#        with:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          BRANCH: gh-pages # The branch the action should deploy to.
+#          FOLDER: . # The folder the action should deploy.
+      -
+        name: Deploy to GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2
         with:
+          target_branch: gh-pages
+          build_dir: .
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: . # The folder the action should deploy.

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -32,3 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: . # The folder the action should deploy.
+
+      - name: Bash2
+        run: |
+          ls -al

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Bash
         run: |
           ls -al
+          git config --global user.email "d.negrier@thecodingmachine.com"
+          git config --global user.name "David Négrier"
           git commit -am "Adding files"
 
 #      - name: Deploy

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,12 +28,10 @@ jobs:
 #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #          BRANCH: gh-pages # The branch the action should deploy to.
 #          FOLDER: . # The folder the action should deploy.
-      -
-        name: Deploy to GitHub Pages
-        if: success()
-        uses: crazy-max/ghaction-github-pages@v2
+
+      - name: Publish generated content to GitHub Pages
+        uses: tsunematsu21/actions-publish-gh-pages@v1.0.1
         with:
-          target_branch: gh-pages
-          build_dir: .
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          dir: dist
+          branch: gh-pages
+          token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,7 +21,8 @@ jobs:
 
       - name: Bash
         uses: jdickey/bash@master
-        args: ["ls -al"]
+        with:
+          args: ["ls -al"]
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -26,16 +26,9 @@ jobs:
           git config --global user.name "David Négrier"
           git commit -am "Adding files"
 
-#      - name: Deploy
-#        uses: JamesIves/github-pages-deploy-action@releases/v3
-#        with:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          BRANCH: gh-pages # The branch the action should deploy to.
-#          FOLDER: . # The folder the action should deploy.
-
-      - name: Publish generated content to GitHub Pages
-        uses: tsunematsu21/actions-publish-gh-pages@v1.0.1
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          dir: .
-          branch: gh-pages
-          token: ${{ secrets.ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: . # The folder the action should deploy.

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,9 +20,7 @@ jobs:
         uses: thecodingmachine/map-optimizer-action@master
 
       - name: Bash
-        uses: jdickey/bash@master
-        with:
-          args: ["ls -al"]
+        run: ls -al
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
                 if (path.endsWith('index.html')) {
                     path = path.substr(path, path.length - 'index.html'.length);
                 }
-                var url = 'https://workadventu.re/_/global/'+window.location.host+path+'map.json';
+                var url = 'https://play.workadventu.re/_/global/'+window.location.host+path+'map.json';
                 document.getElementById('mapLink').href = url;
                 document.getElementById('mapLink').innerText = url;
             };


### PR DESCRIPTION
This PR fixes a bothering visual artifact in the maps by adding a CI pipeline that will rewrite the map and the PNG tilesets.
This will "extrude" the tiles (by adding a 2 px margin between each tile) which fixes the issue.

![image](https://user-images.githubusercontent.com/1290952/86529666-b64a4c00-beb2-11ea-83c4-c9cf464ec06a.png)

Note: the "fixed" map is pushed back to gh-pages branch.

Beware: you will need to change the default Github Pages page from "master" to "gh-pages" (in the settings of your project).

Note: this CI pipeline is now provided by default in the starter kit.